### PR TITLE
Added oculus-go-controls and gearvr-controls to the raycaster options

### DIFF
--- a/index.js
+++ b/index.js
@@ -316,6 +316,8 @@ AFRAME.registerComponent('super-keyboard', {
         '[cursor]',
         '[vive-controls]',
         '[tracked-controls]',
+		'[gearvr-controls]',
+		'[oculus-go-controls]',
         '[oculus-touch-controls]',
         '[windows-motion-controls]',
         '[hand-controls]',


### PR DESCRIPTION
Hi, I was trying your component and it works great on the desktop or in cardboard, but I couldn't get it to work on the Oculus Go. A quick look in the code showed why. The addition of oculus-go-controls fixed the issue. Added gearvr-controls as well.

Cheers,
Thorsten